### PR TITLE
Fix broken tabItem to get native feedback

### DIFF
--- a/src/tab/ExNavigationTabBar.js
+++ b/src/tab/ExNavigationTabBar.js
@@ -86,9 +86,9 @@ export default class ExNavigationTabBar extends React.Component {
             delayPressIn={0}
             background={item.nativeFeedbackBackground}>
             <View style={[styles.tabItem, isSelected ? item.selectedStyle : item.style]}>
-              {title}
               {icon}
               {badge}
+              {title}
             </View>
           </TouchableNativeFeedback>
         );

--- a/src/tab/ExNavigationTabBar.js
+++ b/src/tab/ExNavigationTabBar.js
@@ -84,11 +84,12 @@ export default class ExNavigationTabBar extends React.Component {
             onPress={item.onPress}
             onLongPress={item.onLongPress}
             delayPressIn={0}
-            style={[styles.tabItem, isSelected ? item.selectedStyle : item.style]}
             background={item.nativeFeedbackBackground}>
-            {title}
-            {icon}
-            {badge}
+            <View style={[styles.tabItem, isSelected ? item.selectedStyle : item.style]}>
+              {title}
+              {icon}
+              {badge}
+            </View>
           </TouchableNativeFeedback>
         );
       } else {


### PR DESCRIPTION
TouchableNativeFeedback supports only one child. (refs. [react-native/TouchableNativeFeedback.android.js at master · facebook/react-native · GitHub](https://github.com/facebook/react-native/blob/master/Libraries/Components/Touchable/TouchableNativeFeedback.android.js#L217) )
But, TouchableNativeFeedback has children in `tab/ExNavigationTabBar.js`

I fixed it.