### PR TITLE
Update react-addons-shallow-compare to work with react@16

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lodash": "^4.6.1",
     "mirror-creator": "^1.1.0",
     "react-addons-pure-render-mixin": "^15.5.2",
-    "react-addons-shallow-compare": "15.3.2",
+    "react-addons-shallow-compare": "15.5.2",
     "react-clone-referenced-element": "^1.0.1",
     "react-mixin": "^3.0.5",
     "react-native-drawer-layout-polyfill": "^1.1.0",


### PR DESCRIPTION
Last thing needed for ex-nav to play nicely with react@16