### PR TITLE
Fix error: Cannot read property 'parentNavigatorUID' of undefined

### DIFF
--- a/src/ExNavigationReducer.js
+++ b/src/ExNavigationReducer.js
@@ -81,6 +81,10 @@ class ExNavigationReducer {
   }
 
   static [ActionTypes.REMOVE_NAVIGATOR](state, { navigatorUID }) {
+    const navigatorsKeys = Object.keys(state.navigators)
+    if (!navigatorsKeys.includes(navigatorUID)) {
+      return state
+    }
     const currentNavigatorUID =
       (navigatorsToRestore.length &&
         navigatorsToRestore[navigatorsToRestore.length - 1]) ||


### PR DESCRIPTION
Somehow, State navigators keep omitting the deleted `navigatorUID` when using `rootNavigator.immediatelyResetStack` function in the app.
Proof: [http://imgur.com/a/qiXfL](http://imgur.com/a/qiXfL)