### PR TITLE
Improve SlideHorizontalIOS lookalike

### DIFF
--- a/src/ExNavigationStyles.js
+++ b/src/ExNavigationStyles.js
@@ -109,9 +109,37 @@ function customForHorizontal(props: NavigationSceneRendererProps): Object {
   };
 }
 
+function customForHorizontalIOS(props: NavigationSceneRendererProps): Object {
+  const { layout, position, scene } = props;
+
+  if (!layout.isMeasured) {
+    return forInitial(props);
+  }
+
+  const index = scene.index;
+
+  const opacity = position.interpolate({
+    inputRange: [index - 1, index, index + 1, index + 1.0001],
+    outputRange: ([1, 1, 0.9, 0]: Array<number>),
+    extrapolateRight: "clamp",
+  });
+
+  const shadowOpacity = position.interpolate({
+    inputRange: [index - 1, index, index + 1],
+    outputRange: ([0, 0.4, 0]: Array<number>),
+  });
+
+  return {
+    ...customForHorizontal(props),
+    opacity,
+    shadowRadius: 5,
+    shadowOpacity,
+  };
+}
+
 export const SlideHorizontalIOS: ExNavigationStyles = {
   configureTransition: configureSpringTransition,
-  sceneAnimations: customForHorizontal,
+  sceneAnimations: customForHorizontalIOS,
   navigationBarAnimations: {
     forContainer: (props, delta) => {
       const { layout, position, scene, scenes } = props;


### PR DESCRIPTION
Make `SlideHorizontalIOS` look very close to the transitions seen in ios. 

We don't use native driver yet, so I don't know if animating `shadowOpacity` causes a problem there? If so, maybe we could add this as a separate animation style instead...