### PR TITLE
Bump react-native-tab-view to 0.0.65

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "react-clone-referenced-element": "^1.0.1",
     "react-mixin": "^3.0.5",
     "react-native-drawer-layout-polyfill": "^1.1.0",
-    "react-native-tab-view": "^0.0.61",
+    "react-native-tab-view": "^0.0.65",
     "react-redux": "^4.4.5",
     "react-static-container": "^1.0.0",
     "react-timer-mixin": "^0.13.3",


### PR DESCRIPTION
There is a yellowbox warning right now in expo apps that say:

"View.propTypes has been deprecated and will be removed in a future version of ReactNative. Use ViewPropTypes instead."

`react-native-tab-view` pushed a fix in https://github.com/react-native-community/react-native-tab-view/commit/20e2e96c0fe1c3ea00613c5c121411a29e393e9a