### PR TITLE
Use correct this when setting _wrappedInstance

### DIFF
--- a/src/ExNavigationComponents.js
+++ b/src/ExNavigationComponents.js
@@ -203,7 +203,7 @@ export function withNavigation<T>(
       return this._wrappedInstance;
     }
 
-    setWrappedInstance(ref) {
+    setWrappedInstance = (ref) => {
       this._wrappedInstance = ref;
     }
 


### PR DESCRIPTION
I ran into an issue when trying to use the `withNavigation` HOC with the `withRef` option set to `true`. When using this option the `withNavigation` HOC sets the `_wrappedInstance` on `this`, but it does so on the wrong `this`. This pull request makes the `setWrappedInstance` use the correct `this` so one can use the `getWrappedInstance()` method properly.