### PR TITLE
React.PropTypes => PropTypes, redux ^5.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "invariant": "^2.2.1",
     "lodash": "^4.6.1",
     "mirror-creator": "^1.1.0",
+    "prop-types": "^15.5.10",
     "react-addons-pure-render-mixin": "^15.5.2",
     "react-addons-shallow-compare": "15.5.2",
     "react-clone-referenced-element": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "react-mixin": "^3.0.5",
     "react-native-drawer-layout-polyfill": "^1.1.0",
     "react-native-tab-view": "^0.0.61",
-    "react-redux": "^4.4.5",
+    "react-redux": "^5.0.6",
     "react-static-container": "^1.0.0",
     "react-timer-mixin": "^0.13.3",
     "redux": "^3.5.2",

--- a/src/ExNavigationBar.js
+++ b/src/ExNavigationBar.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import {
   Animated,
   Image,
@@ -9,6 +9,7 @@ import {
   View,
   ViewPropTypes,
 } from 'react-native';
+import PropTypes from 'prop-types';
 import PureComponent from './utils/PureComponent';
 import { unsupportedNativeView } from './ExUnsupportedNativeView';
 import { withNavigation } from './ExNavigationComponents';

--- a/src/ExNavigationComponents.js
+++ b/src/ExNavigationComponents.js
@@ -2,7 +2,8 @@
  * @flow
  */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import UUID from 'uuid-js';
 
@@ -231,7 +232,7 @@ export const createFocusableComponent = (WrappedComponent: ReactClass<any>) => {
     _wrappedInstance: ReactElement<T>;
 
     static childContextTypes = {
-      isFocused: React.PropTypes.bool,
+      isFocused: PropTypes.bool,
     };
 
     getChildContext() {
@@ -329,11 +330,11 @@ export const createFocusAwareComponent = <T>(
 ) => {
   class FocusAwareComponent extends React.Component {
     static contextTypes = {
-      isFocused: React.PropTypes.bool,
+      isFocused: PropTypes.bool,
     };
 
     static childContextTypes = {
-      isFocused: React.PropTypes.bool,
+      isFocused: PropTypes.bool,
     };
 
     _wrappedInstance: ReactElement<T>;

--- a/src/ExNavigationConnect.js
+++ b/src/ExNavigationConnect.js
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import storeShape from 'react-redux/lib/utils/storeShape';
+import { storeShape } from 'react-redux/lib/utils/PropTypes';
 import hoistStatics from 'hoist-non-react-statics';
 import invariant from 'invariant';
 

--- a/src/ExNavigationPropTypes.js
+++ b/src/ExNavigationPropTypes.js
@@ -1,4 +1,4 @@
-import { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 
 export const NavigationPropType = PropTypes.shape({
   getNavigator: PropTypes.func.isRequired,

--- a/src/ExNavigationProvider.js
+++ b/src/ExNavigationProvider.js
@@ -2,8 +2,9 @@
  * @flow
  */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
 import { View, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
 
 import storeShape from 'react-redux/lib/utils/storeShape';
 

--- a/src/ExNavigationProvider.js
+++ b/src/ExNavigationProvider.js
@@ -6,7 +6,7 @@ import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 
-import storeShape from 'react-redux/lib/utils/storeShape';
+import { storeShape } from 'react-redux/lib/utils/PropTypes';
 
 import Actions from './ExNavigationActions';
 import { createBackButtonManager } from './ExNavigationBackButtonManager';

--- a/src/ExNavigationStack.js
+++ b/src/ExNavigationStack.js
@@ -4,6 +4,7 @@
 
 import React from 'react';
 import { Animated, Platform, StyleSheet, View } from 'react-native';
+import PropTypes from 'prop-types';
 import NavigationExperimental from './navigation-experimental';
 
 import _ from 'lodash';
@@ -273,16 +274,16 @@ class ExNavigationStack extends PureComponent<any, Props, State> {
   };
 
   static contextTypes = {
-    parentNavigatorUID: React.PropTypes.string,
-    headerComponent: React.PropTypes.func,
-    alertBarComponent: React.PropTypes.func,
+    parentNavigatorUID: PropTypes.string,
+    headerComponent: PropTypes.func,
+    alertBarComponent: PropTypes.func,
   };
 
   static childContextTypes = {
-    parentNavigatorUID: React.PropTypes.string,
-    navigator: React.PropTypes.instanceOf(ExNavigationStackContext),
-    headerComponent: React.PropTypes.func,
-    alertBarComponent: React.PropTypes.func,
+    parentNavigatorUID: PropTypes.string,
+    navigator: PropTypes.instanceOf(ExNavigationStackContext),
+    headerComponent: PropTypes.func,
+    alertBarComponent: PropTypes.func,
   };
 
   getChildContext() {

--- a/src/ExNavigationStackItem.js
+++ b/src/ExNavigationStackItem.js
@@ -1,5 +1,6 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import { Animated, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
 
 import PureComponent from './utils/PureComponent';
 

--- a/src/ExUnsupportedNativeView.js
+++ b/src/ExUnsupportedNativeView.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import { View } from 'react-native';
 
 export function unsupportedNativeView(name) {

--- a/src/drawer/ExNavigationDrawer.js
+++ b/src/drawer/ExNavigationDrawer.js
@@ -4,6 +4,7 @@
 
 import React, { Children } from 'react';
 import { StyleSheet, View } from 'react-native';
+import PropTypes from 'prop-types';
 import DrawerLayout from 'react-native-drawer-layout-polyfill';
 import PureComponent from '../utils/PureComponent';
 import StaticContainer from 'react-static-container';
@@ -97,12 +98,12 @@ class ExNavigationDrawer extends PureComponent<any, Props, State> {
   };
 
   static contextTypes = {
-    parentNavigatorUID: React.PropTypes.string,
+    parentNavigatorUID: PropTypes.string,
   };
 
   static childContextTypes = {
-    parentNavigatorUID: React.PropTypes.string,
-    navigator: React.PropTypes.instanceOf(ExNavigationDrawerContext),
+    parentNavigatorUID: PropTypes.string,
+    navigator: PropTypes.instanceOf(ExNavigationDrawerContext),
   };
 
   getChildContext() {

--- a/src/navigation-experimental/NavigationCard.js
+++ b/src/navigation-experimental/NavigationCard.js
@@ -39,6 +39,7 @@ const NavigationPagerStyleInterpolator = require('./NavigationPagerStyleInterpol
 const NavigationPointerEventsContainer = require('./NavigationPointerEventsContainer');
 const NavigationPropTypes = require('./NavigationPropTypes');
 const React = require('react');
+const PropTypes = require('prop-types');
 
 import type  {
   NavigationPanPanHandlers,
@@ -54,8 +55,6 @@ type Props = NavigationSceneRendererProps & {
   renderScene: NavigationSceneRenderer,
   style: any,
 };
-
-const {PropTypes} = React;
 
 /**
  * Component that renders the scene as card for the <NavigationCardStack />.

--- a/src/navigation-experimental/NavigationCardStack.js
+++ b/src/navigation-experimental/NavigationCardStack.js
@@ -43,9 +43,9 @@ const {
   View,
   ViewPropTypes,
 } = require('react-native');
+const PropTypes = require('prop-types');
 
 const { NativeAnimatedModule } = NativeModules;
-const { PropTypes } = React;
 const { Directions } = NavigationCardStackPanResponder;
 
 import type {

--- a/src/navigation-experimental/NavigationHeader.js
+++ b/src/navigation-experimental/NavigationHeader.js
@@ -37,6 +37,7 @@ const NavigationHeaderTitle = require('./NavigationHeaderTitle');
 const NavigationPropTypes = require('./NavigationPropTypes');
 const React = require('react');
 const ReactNative = require('react-native');
+const PropTypes = require('prop-types');
 const ReactComponentWithPureRenderMixin = require('react-addons-pure-render-mixin');
 
 const {
@@ -80,7 +81,6 @@ type SubViewName = 'left' | 'title' | 'right';
 
 const APPBAR_HEIGHT = Platform.OS === 'ios' ? 44 : 56;
 const STATUSBAR_HEIGHT = Platform.OS === 'ios' ? 20 : 0;
-const { PropTypes } = React;
 
 class NavigationHeader extends React.Component<DefaultProps, Props, any> {
   props: Props;

--- a/src/navigation-experimental/NavigationHeaderBackButton.js
+++ b/src/navigation-experimental/NavigationHeaderBackButton.js
@@ -24,6 +24,7 @@
 
 const React = require('react');
 const ReactNative = require('react-native');
+const PropTypes = require('prop-types');
 
 const {
   I18nManager,
@@ -46,7 +47,7 @@ const NavigationHeaderBackButton = (props: Props) => (
 );
 
 NavigationHeaderBackButton.propTypes = {
-  onPress: React.PropTypes.func.isRequired
+  onPress: PropTypes.func.isRequired
 };
 
 const styles = StyleSheet.create({

--- a/src/navigation-experimental/NavigationHeaderTitle.js
+++ b/src/navigation-experimental/NavigationHeaderTitle.js
@@ -33,6 +33,7 @@
 
 const React = require('react');
 const ReactNative = require('react-native');
+const PropTypes = require('prop-types');
 
 const { Platform, StyleSheet, View, Text, ViewPropTypes } = ReactNative;
 
@@ -72,7 +73,7 @@ const styles = StyleSheet.create({
 });
 
 NavigationHeaderTitle.propTypes = {
-  children: React.PropTypes.node.isRequired,
+  children: PropTypes.node.isRequired,
   style: ViewPropTypes.style,
   textStyle: Text.propTypes.style,
 };

--- a/src/navigation-experimental/NavigationPropTypes.js
+++ b/src/navigation-experimental/NavigationPropTypes.js
@@ -23,11 +23,10 @@ import type  {
 
 const {Animated} = require('react-native');
 const React = require('react');
-
-const {PropTypes} = React;
+const PropTypes = require('prop-types');
 
 /* NavigationAction */
-const action =  PropTypes.shape({
+const action = PropTypes.shape({
   type: PropTypes.string.isRequired,
 });
 

--- a/src/navigation-experimental/NavigationTransitioner.js
+++ b/src/navigation-experimental/NavigationTransitioner.js
@@ -14,6 +14,7 @@ const {Animated, Easing, StyleSheet, View} = require('react-native');
 const NavigationPropTypes = require('./NavigationPropTypes');
 const NavigationScenesReducer = require('./NavigationScenesReducer');
 const React = require('react');
+const PropTypes = require('prop-types');
 
 const invariant = require('fbjs/lib/invariant');
 
@@ -44,8 +45,6 @@ type State = {
   progress: NavigationAnimatedValue,
   scenes: Array<NavigationScene>,
 };
-
-const {PropTypes} = React;
 
 const DefaultTransitionSpec = {
   duration: 250,

--- a/src/shared-element/ExNavigationSharedElement.js
+++ b/src/shared-element/ExNavigationSharedElement.js
@@ -2,8 +2,9 @@
  * @flow
  */
 
-import React, { Component, PropTypes, cloneElement } from 'react';
+import React, { Component, cloneElement } from 'react';
 import { UIManager, findNodeHandle } from 'react-native';
+import PropTypes from 'prop-types';
 import invariant from 'invariant';
 
 import type {

--- a/src/shared-element/ExNavigationSharedElementGroup.js
+++ b/src/shared-element/ExNavigationSharedElementGroup.js
@@ -3,8 +3,9 @@
  */
 
 import _ from 'lodash';
-import React, { cloneElement, Children, Component, PropTypes } from 'react';
+import React, { cloneElement, Children, Component } from 'react';
 import { Animated, Easing, View } from 'react-native';
+import PropTypes from 'prop-types';
 
 import UUID from 'uuid-js';
 

--- a/src/shared-element/ExNavigationSharedElementOverlay.js
+++ b/src/shared-element/ExNavigationSharedElementOverlay.js
@@ -6,7 +6,7 @@ import React, { cloneElement } from 'react';
 import { View, StyleSheet, findNodeHandle } from 'react-native';
 
 import { createStore } from 'redux';
-import storeShape from 'react-redux/lib/utils/storeShape';
+import { storeShape } from 'react-redux/lib/utils/PropTypes';
 
 import SharedElementReducer from './ExNavigationSharedElementReducer';
 

--- a/src/sliding-tab/ExNavigationSlidingTab.js
+++ b/src/sliding-tab/ExNavigationSlidingTab.js
@@ -4,6 +4,7 @@
 
 import React, { Children } from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
+import PropTypes from 'prop-types';
 import PureComponent from '../utils/PureComponent';
 import StaticContainer from 'react-static-container';
 
@@ -92,12 +93,12 @@ class ExNavigationSlidingTab extends PureComponent<any, Props, State> {
   };
 
   static contextTypes = {
-    parentNavigatorUID: React.PropTypes.string,
+    parentNavigatorUID: PropTypes.string,
   };
 
   static childContextTypes = {
-    parentNavigatorUID: React.PropTypes.string,
-    navigator: React.PropTypes.instanceOf(ExNavigationTabContext),
+    parentNavigatorUID: PropTypes.string,
+    navigator: PropTypes.instanceOf(ExNavigationTabContext),
   };
 
   constructor(props, context) {

--- a/src/tab/ExNavigationTab.js
+++ b/src/tab/ExNavigationTab.js
@@ -4,6 +4,7 @@
 
 import React, { Children } from 'react';
 import { StyleSheet, View } from 'react-native';
+import PropTypes from 'prop-types';
 import PureComponent from '../utils/PureComponent';
 import StaticContainer from 'react-static-container';
 
@@ -98,12 +99,12 @@ class ExNavigationTab extends PureComponent<any, Props, State> {
   };
 
   static contextTypes = {
-    parentNavigatorUID: React.PropTypes.string,
+    parentNavigatorUID: PropTypes.string,
   };
 
   static childContextTypes = {
-    parentNavigatorUID: React.PropTypes.string,
-    navigator: React.PropTypes.instanceOf(ExNavigationTabContext),
+    parentNavigatorUID: PropTypes.string,
+    navigator: PropTypes.instanceOf(ExNavigationTabContext),
   };
 
   getChildContext() {


### PR DESCRIPTION
Hey, @skevy @brentvatne @janicduplessis  please, take a look!
At Tipsi we want to upgrade our app to RN 0.47 because the App even can't start.
This PR brings `prop-types` into ex-navigation 👍 
Also, I've update `react-redux` and fix paths to `storeShape`.

Please, publish updated version into npm we are waiting for you 😢 